### PR TITLE
Juan/Fix frontend axios header

### DIFF
--- a/src/common/useFetchData.jsx
+++ b/src/common/useFetchData.jsx
@@ -10,7 +10,7 @@ export const useFetchData = (pathToFetch) => {
       .get(pathToFetch, {
         headers: {
           "Content-Type": "Application/json",
-          "Access-Control-Allow-Origin": "*",
+          // "Access-Control-Allow-Origin": "*",
         },
       })
       .then((res) => {


### PR DESCRIPTION
The `Access-Control-Allow-Origin` header should be set by the server, not frontend/axios. This resolves the CORS issue.